### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.4.5
+django==1.4
 django-nose
 model_mommy==0.8.1
 django-tastypie 


### PR DESCRIPTION
bug fix, downgread to django 1.4  
http://stackoverflow.com/questions/15408255/cannot-import-name-lookup-sep
